### PR TITLE
Adding an ADR template to use 

### DIFF
--- a/adr/000-adr-template.md
+++ b/adr/000-adr-template.md
@@ -1,0 +1,34 @@
+---
+title: Architecture Decision Record Template
+authors:
+  - Ryan Hertzog
+date_created: 02/13/2025
+last_updated: 02/13/2025
+---
+
+## Status
+
+- The following statuses are considered valid and should be followed by a date; proposed, accepted, and superseded. Example;
+  - Proposed: 02/13/2025
+  - Accepted: 02/13/2025
+
+## Participants
+
+- A list of participants that contributed to the decision should be provided. Example;
+  - Brandon Moriarty
+  - Chris Acton
+  - Megin Mathew
+  - Jagreet Atwal
+  - Ryan Hertzog
+
+## Context
+
+- Provide a description of the problem and pertinent information.
+
+## Decision
+
+- Provide a decision and the justification of why this was decided.
+
+## Consequences
+
+- Provide any positive or negative trade-offs and/or impacts of the decision.


### PR DESCRIPTION
This pull request introduces a new Architecture Decision Record (ADR) template in the `adr` directory. The template is designed to standardize the documentation of architectural decisions.

Key changes include:

* [`adr/000-adr-template.md`](diffhunk://#diff-86115e1fb2f1e7b2b2c73808c6974fc358daf90efcbddb49f2862f5ad28d99e9R1-R34): Added a new ADR template with sections for status, participants, context, decision, and consequences.